### PR TITLE
feat: integrar OpenWA como proveedor WhatsApp y edición de contactos

### DIFF
--- a/api/app/controllers/api/v1/ad_integrations_controller.rb
+++ b/api/app/controllers/api/v1/ad_integrations_controller.rb
@@ -150,13 +150,14 @@ module Api
         base = "#{root}/api/v1/webhooks"
         {
           integration_webhooks: {
-            base_url:                   base,
-            meta_verify_get:            "#{base}/meta",
-            meta_leads_post:            "#{base}/meta",
-            google_leads_post:          "#{base}/google",
-            whatsapp_twilio_post:       "#{base}/whatsapp/twilio",
+            base_url:                  base,
+            meta_verify_get:           "#{base}/meta",
+            meta_leads_post:           "#{base}/meta",
+            google_leads_post:         "#{base}/google",
+            whatsapp_twilio_post:      "#{base}/whatsapp/twilio",
             whatsapp_cloud_verify_get: "#{base}/whatsapp/cloud",
-            whatsapp_cloud_post:        "#{base}/whatsapp/cloud"
+            whatsapp_cloud_post:       "#{base}/whatsapp/cloud",
+            whatsapp_openwa_post:      "#{base}/whatsapp/openwa"
           }
         }
       end

--- a/api/app/controllers/api/v1/webhooks/open_wa_controller.rb
+++ b/api/app/controllers/api/v1/webhooks/open_wa_controller.rb
@@ -1,0 +1,49 @@
+# frozen_string_literal: true
+
+module Api
+  module V1
+    module Webhooks
+      # ========================================================================
+      # Webhooks::OpenWaController — recibe eventos de un servidor OpenWA.
+      # ========================================================================
+      # OpenWA envía una firma HMAC-SHA256 en el header X-OpenWA-Signature
+      # (hex digest sin prefijo) cuando el webhook se configura con `secret`.
+      # Si ENV["OPENWA_WEBHOOK_SECRET"] está vacío, la firma se ignora (dev).
+      # ========================================================================
+      class OpenWaController < BaseController
+        include WebhookEnqueue
+        include WebhookJsonPayload
+
+        skip_before_action :authenticate_user!,            raise: false
+        skip_before_action :verify_user_belongs_to_tenant, raise: false
+        skip_before_action :resolve_tenant!,               raise: false
+        skip_around_action :scope_to_tenant,               raise: false
+
+        before_action :verify_openwa_signature!
+
+        # POST /api/v1/webhooks/whatsapp/openwa
+        def create
+          payload = parsed_webhook_payload
+          return head :bad_request if payload == WebhookJsonPayload::INVALID_JSON_BODY
+
+          enqueue_webhook_processor(
+            "whatsapp_openwa",
+            payload.merge("received_at" => Time.current.iso8601)
+          )
+          head :ok
+        end
+
+        private
+
+        def verify_openwa_signature!
+          secret = ENV["OPENWA_WEBHOOK_SECRET"].to_s
+          return if secret.blank?
+
+          signature = request.headers["X-OpenWA-Signature"].to_s
+          expected  = OpenSSL::HMAC.hexdigest("SHA256", secret, request.raw_post)
+          head :forbidden unless ActiveSupport::SecurityUtils.secure_compare(signature, expected)
+        end
+      end
+    end
+  end
+end

--- a/api/app/controllers/api/v1/whatsapp_messages_controller.rb
+++ b/api/app/controllers/api/v1/whatsapp_messages_controller.rb
@@ -50,9 +50,10 @@ module Api
         if from_number.blank?
           return render json: {
             error:   "whatsapp_not_configured",
-            message: "Configura el envío saliente: Ajustes → Integraciones (WhatsApp Cloud API o Twilio) " \
-                     "con credenciales y Phone number ID / número E.164; o variables " \
-                     "WHATSAPP_CLOUD_* / TWILIO_WHATSAPP_NUMBER y settings whatsapp.number."
+            message: "Configura el envío saliente en Ajustes → Integraciones: " \
+                     "WhatsApp Cloud API (Phone number ID + access token), " \
+                     "Twilio (Account SID + Auth Token + número E.164) " \
+                     "u OpenWA (URL + API Key + Session ID)."
           }, status: :unprocessable_entity
         end
 

--- a/api/app/jobs/webhook_processor_job.rb
+++ b/api/app/jobs/webhook_processor_job.rb
@@ -34,10 +34,11 @@ class WebhookProcessorJob < ApplicationJob
     audit_received(kind, payload)
 
     case kind
-    when "meta", "meta_ads" then Ads::MetaLeadProcessor.new(payload).call
+    when "meta", "meta_ads"    then Ads::MetaLeadProcessor.new(payload).call
     when "google", "google_ads" then Ads::GoogleLeadProcessor.new(payload).call
-    when "whatsapp_twilio" then process_whatsapp_twilio(payload)
-    when "whatsapp_cloud"  then process_whatsapp_cloud(payload)
+    when "whatsapp_twilio"     then process_whatsapp_twilio(payload)
+    when "whatsapp_cloud"      then process_whatsapp_cloud(payload)
+    when "whatsapp_openwa"     then process_whatsapp_openwa(payload)
     else
       Rails.logger.warn("[WebhookProcessorJob] kind desconocido: #{kind}")
     end
@@ -167,6 +168,97 @@ class WebhookProcessorJob < ApplicationJob
         end
       end
     end
+  end
+
+  # --- WhatsApp inbound (OpenWA) ----------------------------------------
+
+  def process_whatsapp_openwa(payload)
+    event      = payload["event"].to_s
+    session_id = payload["sessionId"].to_s
+    data       = payload["data"].is_a?(Hash) ? payload["data"] : {}
+
+    msg_id = openwa_extract_message_id(data)
+
+    case event
+    when "message.received"
+      process_openwa_inbound(session_id, data, msg_id)
+    when "message.delivered"
+      openwa_update_status(msg_id, "delivered", delivered_at: true)
+    when "message.read"
+      openwa_update_status(msg_id, "read", read_at: true)
+    when "message.failed"
+      openwa_update_status(msg_id, "failed")
+    else
+      Rails.logger.info("[WhatsApp OpenWA] evento ignorado: #{event}")
+    end
+  end
+
+  def process_openwa_inbound(session_id, data, msg_id)
+    from_wa = data["from"].to_s
+    to_wa   = data["to"].to_s
+
+    from_number = openwa_wa_id_to_e164(from_wa)
+    to_number   = openwa_wa_id_to_e164(to_wa)
+
+    tenant = AdIntegration.unscoped
+                          .where(provider: "openwa", account_identifier: session_id)
+                          .first&.tenant
+    tenant ||= resolve_tenant_by_setting("whatsapp.openwa_session_id", session_id)
+
+    return Rails.logger.warn("[WhatsApp OpenWA] sin tenant para sessionId=#{session_id}") unless tenant
+
+    ActsAsTenant.with_tenant(tenant) do
+      if msg_id.present? &&
+         tenant.whatsapp_messages.exists?(provider: "openwa", provider_message_id: msg_id)
+        Rails.logger.info("[WhatsApp OpenWA] duplicado msg_id=#{msg_id}")
+        return
+      end
+
+      contact     = upsert_contact(tenant, from_number)
+      opportunity = find_opportunity_for_inbound(tenant, contact, from_number)
+      tenant.whatsapp_messages.create!(
+        contact:             contact,
+        opportunity:         opportunity,
+        direction:           "in",
+        provider:            "openwa",
+        provider_message_id: msg_id,
+        from_number:         from_number,
+        to_number:           to_number,
+        body:                data["body"].to_s,
+        status:              "delivered",
+        raw_payload:         data
+      )
+      opportunity&.touch_activity!
+    end
+  end
+
+  def openwa_extract_message_id(data)
+    id_field = data["id"]
+    if id_field.is_a?(Hash)
+      id_field["_serialized"].to_s.presence
+    else
+      id_field.to_s.presence
+    end
+  end
+
+  # Convierte chatId de whatsapp-web.js (628123456789@c.us) a E.164 (+628123456789)
+  def openwa_wa_id_to_e164(wa_id)
+    digits = wa_id.to_s.split("@").first.to_s.gsub(/\D/, "")
+    digits.blank? ? wa_id : "+#{digits}"
+  end
+
+  def openwa_update_status(msg_id, new_status, delivered_at: false, read_at: false)
+    return if msg_id.blank?
+
+    msg = WhatsappMessage.unscoped.find_by(provider: "openwa", provider_message_id: msg_id)
+    return unless msg
+
+    attrs = { status: new_status }
+    attrs[:delivered_at] = Time.current if delivered_at && msg.delivered_at.blank?
+    attrs[:read_at]      = Time.current if read_at      && msg.read_at.blank?
+    ActsAsTenant.with_tenant(msg.tenant) { msg.update!(attrs) }
+  rescue ActiveRecord::RecordInvalid => e
+    Rails.logger.warn("[WhatsApp OpenWA] no se pudo actualizar estado: #{e.message}")
   end
 
   def resolve_tenant_by_setting(path, value)

--- a/api/app/models/ad_integration.rb
+++ b/api/app/models/ad_integration.rb
@@ -9,7 +9,7 @@
 class AdIntegration < ApplicationRecord
   include TenantScoped
 
-  PROVIDERS = %w[meta google twilio whatsapp_cloud].freeze
+  PROVIDERS = %w[meta google twilio whatsapp_cloud openwa].freeze
   STATUSES  = %w[active paused error revoked].freeze
 
   enum :provider, PROVIDERS.zip(PROVIDERS).to_h, prefix: true

--- a/api/app/models/tenant.rb
+++ b/api/app/models/tenant.rb
@@ -62,6 +62,12 @@ class Tenant < ApplicationRecord
       base.order(updated_at: :desc).first
   end
 
+  def preferred_openwa_integration
+    base = AdIntegration.unscoped.where(tenant_id: id, provider: :openwa)
+    base.where(status: "active").order(updated_at: :desc).first ||
+      base.order(updated_at: :desc).first
+  end
+
   # Número/línea usado como remitente en mensajes WhatsApp salientes (Twilio API).
   # Orden: settings del tenant → ENV → integración Twilio (`account_identifier`).
   def whatsapp_outbound_from_number
@@ -76,24 +82,26 @@ class Tenant < ApplicationRecord
       preferred_whatsapp_cloud_integration&.account_identifier.presence
   end
 
-  # Twilio vs WhatsApp Cloud API para mensajes salientes.
+  # Twilio vs WhatsApp Cloud API vs OpenWA para mensajes salientes.
   # Prioridad: ENV["WHATSAPP_PROVIDER"] → settings["whatsapp"]["provider"] →
-  # si Cloud y Twilio tienen credenciales, preferimos Cloud; si solo uno, ese.
+  # si hay credenciales, preferimos Cloud > Twilio > OpenWA.
   def whatsapp_outbound_provider
     exp = ENV["WHATSAPP_PROVIDER"].to_s.strip
-    return exp if %w[twilio whatsapp_cloud].include?(exp)
+    return exp if %w[twilio whatsapp_cloud openwa].include?(exp)
 
     override = settings.dig("whatsapp", "provider").to_s.strip
-    return override if %w[twilio whatsapp_cloud].include?(override)
+    return override if %w[twilio whatsapp_cloud openwa].include?(override)
 
-    cloud_i  = preferred_whatsapp_cloud_integration
-    twilio_i = preferred_twilio_integration
-    cloud_ok = ad_integration_has_credentials?(cloud_i)
+    cloud_i   = preferred_whatsapp_cloud_integration
+    twilio_i  = preferred_twilio_integration
+    openwa_i  = preferred_openwa_integration
+    cloud_ok  = ad_integration_has_credentials?(cloud_i)
     twilio_ok = ad_integration_has_credentials?(twilio_i)
+    openwa_ok = ad_integration_has_credentials?(openwa_i)
 
-    return "whatsapp_cloud" if cloud_ok && twilio_ok
     return "whatsapp_cloud" if cloud_ok
-    return "twilio" if twilio_ok
+    return "twilio"         if twilio_ok
+    return "openwa"         if openwa_ok
 
     "twilio"
   end
@@ -104,6 +112,10 @@ class Tenant < ApplicationRecord
       whatsapp_cloud_sender_label.presence ||
         whatsapp_outbound_from_number.presence ||
         "whatsapp-cloud"
+    when "openwa"
+      settings.dig("whatsapp", "openwa_number").presence ||
+        preferred_openwa_integration&.account_identifier.presence ||
+        "openwa"
     else
       whatsapp_outbound_from_number
     end

--- a/api/app/models/tenant.rb
+++ b/api/app/models/tenant.rb
@@ -125,6 +125,7 @@ class Tenant < ApplicationRecord
 
   def ad_integration_has_credentials?(integ)
     integ.present? &&
+      integ.status == "active" &&
       integ.respond_to?(:credentials_ciphertext) &&
       integ.credentials_ciphertext.present?
   end

--- a/api/app/models/whatsapp_message.rb
+++ b/api/app/models/whatsapp_message.rb
@@ -8,7 +8,7 @@ class WhatsappMessage < ApplicationRecord
   include DataClassifiable
 
   DIRECTIONS = %w[in out].freeze
-  PROVIDERS  = %w[twilio whatsapp_cloud].freeze
+  PROVIDERS  = %w[twilio whatsapp_cloud openwa].freeze
   STATUSES   = %w[pending queued sent delivered read failed].freeze
 
   enum :direction, DIRECTIONS.zip(DIRECTIONS).to_h, prefix: true

--- a/api/app/services/ads/connection_tester.rb
+++ b/api/app/services/ads/connection_tester.rb
@@ -39,6 +39,8 @@ module Ads
       when "twilio"          then test_twilio
       when "whatsapp_cloud"
         test_whatsapp_cloud
+      when "openwa"
+        test_openwa
       else
         Rails.logger.warn("ConnectionTester: provider '#{@integration.provider}' sin implementar, stub OK")
         Result.new(ok: true, message: nil)
@@ -216,6 +218,112 @@ module Ads
           end
         fail_result(hint)
       end
+    end
+
+    # GET {url}/api/sessions/{session_id} — verifica URL, API key y que la sesión existe.
+    # OpenWA devuelve 200 + JSON con el estado de la sesión cuando las credenciales son válidas.
+    # Test en dos pasos:
+    #   1. GET /api/sessions  → valida URL + API key y detecta la sesión en la lista
+    #   2. Si ese endpoint no existe (404), intenta GET / como health-check mínimo
+    # Ambos pasos se hacen con el header X-API-Key.
+    def test_openwa
+      creds      = @creds.stringify_keys
+      url        = creds["url"].to_s.strip.chomp("/")
+      api_key    = creds["api_key"].to_s.strip
+      session_id = (@integration.account_identifier.to_s.strip.presence ||
+                    creds["session_id"].to_s.strip).presence
+
+      return fail_result("Falta la URL del servidor OpenWA en las credenciales.") if url.blank?
+      return fail_result("Falta la API Key de OpenWA en las credenciales.")       if api_key.blank?
+      return fail_result("Falta el Session ID de OpenWA. Escríbelo en el campo «Session ID» de la integración.") if session_id.blank?
+
+      conn = Faraday.new(url: url) do |f|
+        f.response :json, content_type: /\bjson$/
+        f.options.timeout      = TIMEOUT_SECONDS
+        f.options.open_timeout = TIMEOUT_SECONDS
+      end
+
+      res = conn.get("/api/sessions") { |req| req.headers["X-API-Key"] = api_key }
+
+      case res.status
+      when 200
+        openwa_check_session_in_list(res.body, session_id)
+      when 401, 403
+        fail_result("OpenWA rechazó la API Key. Verifica la clave en el panel de OpenWA.")
+      when 404
+        # El endpoint /api/sessions no existe en esta versión; intentamos un health-check mínimo.
+        openwa_fallback_health(conn, api_key, url)
+      else
+        detail = openwa_error_detail(res.body)
+        Rails.logger.warn("ConnectionTester openwa: GET /api/sessions → HTTP #{res.status} — #{detail}")
+        fail_result("OpenWA respondió HTTP #{res.status}. Comprueba la URL y que el servidor esté en línea.")
+      end
+    rescue Faraday::ConnectionFailed, Faraday::TimeoutError => e
+      Rails.logger.warn("ConnectionTester openwa: #{e.class} #{e.message}")
+      fail_result("No se pudo conectar al servidor OpenWA (#{url}). Verifica que el servidor esté en línea y la URL sea correcta.")
+    end
+
+    # Busca session_id en la lista que devuelve GET /api/sessions.
+    # Acepta Array de strings, Array de hashes con campo id/sessionId/name, o Hash indexado.
+    def openwa_check_session_in_list(body, session_id)
+      ids =
+        case body
+        when Array
+          body.filter_map do |item|
+            case item
+            when String then item
+            when Hash   then item["id"] || item["sessionId"] || item["name"] || item["session"]
+            end
+          end
+        when Hash
+          # Algunas versiones devuelven { sessions: [...] } o { data: [...] }
+          inner = body["sessions"] || body["data"] || body.values.first
+          return openwa_check_session_in_list(inner, session_id) if inner.is_a?(Array)
+          body.keys
+        else
+          []
+        end
+
+      if ids.map(&:to_s).include?(session_id.to_s)
+        Result.new(ok: true, message: nil)
+      else
+        Rails.logger.info("ConnectionTester openwa: sesiones disponibles: #{ids.inspect}")
+        if ids.empty?
+          fail_result(
+            "El servidor OpenWA no tiene sesiones activas. " \
+            "Inicia la sesión «#{session_id}» escaneando el código QR en el panel de OpenWA."
+          )
+        else
+          fail_result(
+            "Session «#{session_id}» no encontrada. " \
+            "Sesiones disponibles: #{ids.map(&:to_s).join(', ')}. " \
+            "Verifica el Session ID en la integración."
+          )
+        end
+      end
+    end
+
+    # Health-check mínimo cuando /api/sessions devuelve 404 (versión de OpenWA sin ese endpoint).
+    # Si el servidor responde cualquier HTTP (incluso 404 en /) con la API key correcta, damos OK.
+    def openwa_fallback_health(conn, api_key, url)
+      res = conn.get("/") { |req| req.headers["X-API-Key"] = api_key }
+      case res.status
+      when 401, 403
+        fail_result("OpenWA rechazó la API Key. Verifica la clave en el panel de OpenWA.")
+      else
+        # El servidor responde → URL y API key parecen correctas.
+        # No podemos verificar la sesión con esta versión de OpenWA.
+        Rails.logger.info("ConnectionTester openwa: fallback health OK (HTTP #{res.status}) — #{url}")
+        Result.new(ok: true, message: nil)
+      end
+    rescue Faraday::ConnectionFailed, Faraday::TimeoutError
+      fail_result("No se pudo conectar al servidor OpenWA (#{url}).")
+    end
+
+    def openwa_error_detail(body)
+      return "respuesta no JSON" unless body.is_a?(Hash)
+
+      (body["message"] || body["error"] || body.to_s).to_s.truncate(200)
     end
 
     def fail_result(message)

--- a/api/app/services/whats_app/adapters/open_wa.rb
+++ b/api/app/services/whats_app/adapters/open_wa.rb
@@ -1,0 +1,90 @@
+# frozen_string_literal: true
+
+module WhatsApp
+  module Adapters
+    # ==========================================================================
+    # WhatsApp::Adapters::OpenWa — envío vía OpenWA (auto-hospedado).
+    # ==========================================================================
+    # OpenWA expone una REST API sobre whatsapp-web.js. No requiere cuenta
+    # Business de Meta ni Twilio, pero viola los ToS de WhatsApp.
+    #
+    # Endpoint:  POST {url}/api/sessions/{sessionId}/messages/send-text
+    # Auth:      Header X-API-Key
+    # Body:      JSON { chatId: "628123456789@c.us", text: "..." }
+    #
+    # Credenciales (por prioridad):
+    #   1. tenant.settings["whatsapp"]["openwa_url"] / ..._api_key / ..._session_id
+    #   2. AdIntegration(provider: openwa) → url/api_key en credentials,
+    #      session_id en account_identifier
+    #   3. ENV: OPENWA_URL, OPENWA_API_KEY, OPENWA_SESSION_ID
+    # ==========================================================================
+    class OpenWa < Base
+      def deliver(message)
+        url, api_key, session_id = openwa_credentials
+
+        raise_delivery!("Credenciales OpenWA incompletas para tenant #{@tenant.id}. " \
+                         "Configura url, api_key y session_id en Ajustes → Integraciones (OpenWA).") if
+          url.blank? || api_key.blank? || session_id.blank?
+
+        chat_id = normalize_openwa_chat_id(message.to_number)
+
+        conn = Faraday.new(url: url) do |f|
+          f.request  :json
+          f.response :json, content_type: /\bjson$/
+          f.options.timeout      = DEFAULT_TIMEOUT
+          f.options.open_timeout = DEFAULT_TIMEOUT
+        end
+
+        res = conn.post("/api/sessions/#{session_id}/messages/send-text") do |req|
+          req.headers["X-API-Key"]    = api_key
+          req.headers["Content-Type"] = "application/json"
+          req.body = { chatId: chat_id, text: message.body.to_s }
+        end
+
+        unless res.success?
+          raise_delivery!("OpenWA: HTTP #{res.status} — #{extract_openwa_error(res.body)}")
+        end
+
+        body   = res.body.is_a?(Hash) ? res.body : {}
+        msg_id = body["id"].is_a?(Hash) ? body["id"]["_serialized"].to_s : body["id"].to_s
+        {
+          provider_message_id: msg_id.presence,
+          status:              "sent"
+        }
+      end
+
+      private
+
+      def openwa_credentials
+        url        = tenant_setting(:openwa_url,        "OPENWA_URL")
+        api_key    = tenant_setting(:openwa_api_key,    "OPENWA_API_KEY")
+        session_id = tenant_setting(:openwa_session_id, "OPENWA_SESSION_ID")
+
+        if url.blank? || api_key.blank? || session_id.blank?
+          integ = @tenant.preferred_openwa_integration
+          if integ
+            creds      = (integ.credentials || {}).stringify_keys
+            url        = url.presence        || creds["url"].presence
+            api_key    = api_key.presence    || creds["api_key"].presence
+            session_id = session_id.presence || integ.account_identifier.presence ||
+                         creds["session_id"].presence
+          end
+        end
+
+        [url&.strip&.chomp("/"), api_key&.strip, session_id&.strip]
+      end
+
+      # Convierte E.164 (+628123456789) al chatId de whatsapp-web.js (628123456789@c.us)
+      def normalize_openwa_chat_id(number)
+        digits = number.to_s.strip.delete_prefix("+").gsub(/\D/, "")
+        "#{digits}@c.us"
+      end
+
+      def extract_openwa_error(body)
+        return "respuesta inválida" unless body.is_a?(Hash)
+
+        body["message"] || body["error"] || body.to_s.truncate(200)
+      end
+    end
+  end
+end

--- a/api/app/services/whats_app/message_sender.rb
+++ b/api/app/services/whats_app/message_sender.rb
@@ -20,7 +20,8 @@ module WhatsApp
     ADAPTERS = {
       "twilio"         => "WhatsApp::Adapters::Twilio",
       "whatsapp_cloud" => "WhatsApp::Adapters::Cloud",
-      "cloud"          => "WhatsApp::Adapters::Cloud"
+      "cloud"          => "WhatsApp::Adapters::Cloud",
+      "openwa"         => "WhatsApp::Adapters::OpenWa"
     }.freeze
 
     def initialize(message)

--- a/api/config/routes.rb
+++ b/api/config/routes.rb
@@ -195,9 +195,12 @@ Rails.application.routes.draw do
         post "/google",          to: "google_ads#create"
 
         # WhatsApp — Twilio y Cloud API
-        post "/whatsapp/twilio", to: "whatsapp#twilio"
-        post "/whatsapp/cloud",  to: "whatsapp#cloud"
-        get  "/whatsapp/cloud",  to: "whatsapp#verify_cloud"
+        post "/whatsapp/twilio",  to: "whatsapp#twilio"
+        post "/whatsapp/cloud",   to: "whatsapp#cloud"
+        get  "/whatsapp/cloud",   to: "whatsapp#verify_cloud"
+
+        # WhatsApp — OpenWA (auto-hospedado)
+        post "/whatsapp/openwa",  to: "open_wa#create"
       end
 
       # ========================================================================

--- a/client/src/components/contacts/ContactEditDialog.tsx
+++ b/client/src/components/contacts/ContactEditDialog.tsx
@@ -1,0 +1,182 @@
+import { useEffect, useState } from 'react'
+import { useMutation, useQueryClient } from '@tanstack/react-query'
+import { toast } from 'sonner'
+import { Button } from '@/components/ui/button'
+import {
+  Dialog,
+  DialogContent,
+  DialogFooter,
+  DialogHeader,
+  DialogTitle,
+} from '@/components/ui/dialog'
+import { Input } from '@/components/ui/input'
+import { Label } from '@/components/ui/label'
+import { Spinner } from '@/components/ui/spinner'
+import api, { formatRailsError } from '@/lib/api'
+import { queryKeys } from '@/lib/queryClient'
+
+export interface ContactEditInitialData {
+  firstName?: string
+  lastName?: string
+  email?: string
+  phone?: string
+  company?: string
+  position?: string
+}
+
+interface ContactEditDialogProps {
+  contactId: string | null
+  initialData?: ContactEditInitialData
+  open: boolean
+  onOpenChange: (open: boolean) => void
+  /** Llamado tras guardar exitosamente */
+  onSaved?: () => void
+}
+
+export function ContactEditDialog({
+  contactId,
+  initialData,
+  open,
+  onOpenChange,
+  onSaved,
+}: ContactEditDialogProps) {
+  const queryClient = useQueryClient()
+
+  const [form, setForm] = useState({
+    firstName: '',
+    lastName: '',
+    email: '',
+    phone: '',
+    company: '',
+    position: '',
+  })
+
+  useEffect(() => {
+    if (open && initialData) {
+      setForm({
+        firstName: initialData.firstName ?? '',
+        lastName:  initialData.lastName  ?? '',
+        email:     initialData.email     ?? '',
+        phone:     initialData.phone     ?? '',
+        company:   initialData.company   ?? '',
+        position:  initialData.position  ?? '',
+      })
+    }
+  }, [open, initialData])
+
+  const set = (field: keyof typeof form, value: string) =>
+    setForm((prev) => ({ ...prev, [field]: value }))
+
+  const mutation = useMutation({
+    mutationFn: async () => {
+      if (!contactId) throw new Error('Sin contacto seleccionado')
+      return api.patch(`/contacts/${contactId}`, {
+        contact: {
+          first_name: form.firstName || undefined,
+          last_name:  form.lastName  || undefined,
+          email:      form.email     || undefined,
+          phone_e164: form.phone     || undefined,
+          company:    form.company   || undefined,
+          position:   form.position  || undefined,
+        },
+      })
+    },
+    onSuccess: async () => {
+      // Invalida contactos Y oportunidades para que los cambios se reflejen en ambos lados
+      await Promise.all([
+        queryClient.invalidateQueries({ queryKey: queryKeys.contacts.all }),
+        queryClient.invalidateQueries({ queryKey: queryKeys.opportunities.all }),
+      ])
+      toast.success('Contacto actualizado')
+      onOpenChange(false)
+      onSaved?.()
+    },
+    onError: (err: unknown) => {
+      toast.error(formatRailsError(err, 'No se pudo actualizar el contacto'))
+    },
+  })
+
+  return (
+    <Dialog open={open} onOpenChange={onOpenChange}>
+      <DialogContent className="sm:max-w-md">
+        <DialogHeader>
+          <DialogTitle>Editar contacto</DialogTitle>
+        </DialogHeader>
+        <form
+          className="space-y-4"
+          onSubmit={(e) => {
+            e.preventDefault()
+            mutation.mutate()
+          }}
+        >
+          <div className="grid grid-cols-2 gap-4">
+            <div className="space-y-2">
+              <Label htmlFor="ce-first-name">Nombre</Label>
+              <Input
+                id="ce-first-name"
+                value={form.firstName}
+                onChange={(e) => set('firstName', e.target.value)}
+              />
+            </div>
+            <div className="space-y-2">
+              <Label htmlFor="ce-last-name">Apellido</Label>
+              <Input
+                id="ce-last-name"
+                value={form.lastName}
+                onChange={(e) => set('lastName', e.target.value)}
+              />
+            </div>
+          </div>
+          <div className="space-y-2">
+            <Label htmlFor="ce-email">Email</Label>
+            <Input
+              id="ce-email"
+              type="email"
+              value={form.email}
+              onChange={(e) => set('email', e.target.value)}
+            />
+          </div>
+          <div className="space-y-2">
+            <Label htmlFor="ce-phone">Teléfono</Label>
+            <Input
+              id="ce-phone"
+              value={form.phone}
+              onChange={(e) => set('phone', e.target.value)}
+              placeholder="+57..."
+            />
+          </div>
+          <div className="space-y-2">
+            <Label htmlFor="ce-company">Empresa</Label>
+            <Input
+              id="ce-company"
+              value={form.company}
+              onChange={(e) => set('company', e.target.value)}
+            />
+          </div>
+          <div className="space-y-2">
+            <Label htmlFor="ce-position">Cargo</Label>
+            <Input
+              id="ce-position"
+              value={form.position}
+              onChange={(e) => set('position', e.target.value)}
+            />
+          </div>
+          <DialogFooter>
+            <Button
+              type="button"
+              variant="outline"
+              onClick={() => onOpenChange(false)}
+              disabled={mutation.isPending}
+            >
+              Cancelar
+            </Button>
+            <Button type="submit" disabled={mutation.isPending}>
+              {mutation.isPending && <Spinner className="mr-2 size-4" />}
+              Guardar cambios
+            </Button>
+          </DialogFooter>
+        </form>
+      </DialogContent>
+    </Dialog>
+  )
+}

--- a/client/src/components/opportunities/OpportunitySlideOver.tsx
+++ b/client/src/components/opportunities/OpportunitySlideOver.tsx
@@ -2,7 +2,7 @@ import { useState } from 'react'
 import { useQuery, useMutation, useQueryClient } from '@tanstack/react-query'
 import { motion, AnimatePresence } from 'framer-motion'
 import { toast } from 'sonner'
-import { X, Building, MessageSquare, FileText, Bell, History } from 'lucide-react'
+import { X, Building, MessageSquare, FileText, Bell, History, Pencil } from 'lucide-react'
 import api from '@/lib/api'
 import {
   jsonApiIncluded,
@@ -34,6 +34,7 @@ import { ActivityLog } from './ActivityLog'
 import { RemindersTab } from './RemindersTab'
 import { WhatsAppThread, type ThreadMessage } from './WhatsAppThread'
 import { ContactActionButtons } from './ContactActionButtons'
+import { ContactEditDialog } from '@/components/contacts/ContactEditDialog'
 import type { Opportunity } from '@/types'
 
 interface OpportunitySlideOverProps {
@@ -49,6 +50,7 @@ export function OpportunitySlideOver({
 }: OpportunitySlideOverProps) {
   const queryClient = useQueryClient()
   const [activeTab, setActiveTab] = useState('overview')
+  const [editContactOpen, setEditContactOpen] = useState(false)
 
   // Fetch activity logs
   const { data: logs, isLoading: logsLoading } = useQuery({
@@ -160,6 +162,7 @@ export function OpportunitySlideOver({
   if (!opportunity) return null
 
   return (
+    <>
     <AnimatePresence>
       {open && (
         <>
@@ -190,6 +193,17 @@ export function OpportunitySlideOver({
                   <Badge className={cn(getStatusColor(opportunity.status))}>
                     {formatStatusLabel(opportunity.status)}
                   </Badge>
+                  {opportunity.contact_id && (
+                    <Button
+                      variant="ghost"
+                      size="icon-sm"
+                      className="shrink-0 text-muted-foreground hover:text-foreground"
+                      onClick={() => setEditContactOpen(true)}
+                      title="Editar contacto"
+                    >
+                      <Pencil className="size-3.5" />
+                    </Button>
+                  )}
                 </div>
                 {opportunity.company_name && (
                   <p className="text-sm text-muted-foreground flex items-center gap-1">
@@ -409,5 +423,19 @@ export function OpportunitySlideOver({
         </>
       )}
     </AnimatePresence>
+
+    <ContactEditDialog
+      contactId={opportunity?.contact_id ?? null}
+      initialData={{
+        firstName: opportunity?.contact_name?.split(' ')[0] ?? '',
+        lastName:  opportunity?.contact_name?.split(' ').slice(1).join(' ') ?? '',
+        email:     opportunity?.contact_email,
+        phone:     opportunity?.contact_phone,
+        company:   opportunity?.company_name,
+      }}
+      open={editContactOpen}
+      onOpenChange={setEditContactOpen}
+    />
+    </>
   )
 }

--- a/client/src/components/opportunities/OpportunitySlideOver.tsx
+++ b/client/src/components/opportunities/OpportunitySlideOver.tsx
@@ -95,6 +95,7 @@ export function OpportunitySlideOver({
             content: String(a.body ?? ''),
             timestamp: String(a.created_at ?? ''),
             isOutgoing: dir === 'out' || dir.endsWith('_out'),
+            provider: String(a.provider ?? ''),
             status: (allowed.includes(st as ThreadMessage['status'])
               ? st
               : 'sent') as ThreadMessage['status'],

--- a/client/src/components/opportunities/WhatsAppThread.tsx
+++ b/client/src/components/opportunities/WhatsAppThread.tsx
@@ -30,8 +30,9 @@ export type ThreadMessage = {
   content: string
   timestamp: string
   isOutgoing: boolean
+  /** Proveedor: twilio | whatsapp_cloud | openwa */
+  provider?: string
   status: 'pending' | 'queued' | 'sent' | 'delivered' | 'read' | 'failed'
-  /** Texto de Twilio/Meta si `status` es `failed` */
   errorMessage?: string
 }
 
@@ -63,13 +64,23 @@ export function WhatsAppThread({
 
   const canSend = toNumber.replace(/\D/g, '').length >= 10
 
-  const twilioAuthIssue = messages.some(
-    (m) =>
-      m.status === 'failed' &&
-      (m.errorMessage?.includes('Authenticate') ||
-        m.errorMessage?.includes('Authentication Error') ||
-        m.errorMessage?.includes('invalid username'))
-  )
+  const authIssueMessage = messages
+    .filter((m) => m.status === 'failed' && m.isOutgoing)
+    .reduce<string | null>((found, m) => {
+      if (found) return found
+      const err = m.errorMessage ?? ''
+      if (
+        err.includes('Authenticate') ||
+        err.includes('Authentication Error') ||
+        err.includes('invalid username') ||
+        err.includes('rechazó la API Key') ||
+        err.includes('Credenciales') ||
+        err.includes('credentials')
+      ) {
+        return err
+      }
+      return null
+    }, null)
 
   const clearMutation = useMutation({
     mutationFn: async () => {
@@ -100,7 +111,7 @@ export function WhatsAppThread({
         toast.error(
           err && String(err).trim()
             ? String(err)
-            : 'Twilio/Meta rechazó el envío. En sandbox de Twilio el contacto debe unirse primero; revisa logs del API.'
+            : 'El proveedor rechazó el envío. Revisa las credenciales en Ajustes → Integraciones y los logs del API.'
         )
       } else {
         toast.success('Mensaje enviado')
@@ -140,28 +151,28 @@ export function WhatsAppThread({
 
   return (
     <div className="flex min-h-0 flex-1 flex-col overflow-hidden rounded-lg border">
-      {twilioAuthIssue && (
+      {authIssueMessage && (
         <div className="shrink-0 border-b border-destructive/30 bg-destructive/10 px-3 py-2 text-xs text-destructive">
           <div className="flex gap-2">
             <AlertCircle className="mt-0.5 size-4 shrink-0" />
             <div className="space-y-1">
               <p className="font-medium text-foreground">
-                Twilio rechaza el envío: credenciales incorrectas (Account SID y Auth Token deben ser de la
-                misma cuenta).
+                Error de credenciales al enviar mensajes.
               </p>
               {canManageIntegrations ? (
                 <p>
-                  Edita la integración Twilio en{' '}
+                  Revisa las credenciales en{' '}
                   <Link
                     to="/settings/integrations"
                     className="font-medium underline underline-offset-2 text-primary"
                   >
                     Ajustes → Integraciones
-                  </Link>{' '}
-                  y vuelve a pegar Account SID (empieza por AC) y Auth Token sin espacios.
+                  </Link>
+                  {': '}
+                  {authIssueMessage.trim().slice(0, 160)}
                 </p>
               ) : (
-                <p>Contacta al administrador para corregir las credenciales de Twilio.</p>
+                <p>Contacta al administrador para corregir las credenciales del proveedor de mensajería.</p>
               )}
             </div>
           </div>

--- a/client/src/lib/adIntegrationsApi.ts
+++ b/client/src/lib/adIntegrationsApi.ts
@@ -6,7 +6,7 @@ import {
 } from '@/lib/opportunityApi'
 
 /** Coincide con `AdIntegration::PROVIDERS` en el API */
-export type AdIntegrationProvider = 'meta' | 'google' | 'twilio' | 'whatsapp_cloud'
+export type AdIntegrationProvider = 'meta' | 'google' | 'twilio' | 'whatsapp_cloud' | 'openwa'
 
 export type AdIntegrationStatus = 'active' | 'paused' | 'error' | 'revoked'
 
@@ -58,6 +58,7 @@ export interface IntegrationWebhookUrls {
   whatsapp_twilio_post: string
   whatsapp_cloud_verify_get: string
   whatsapp_cloud_post: string
+  whatsapp_openwa_post: string
 }
 
 export interface AdIntegrationsIndexResult {

--- a/client/src/lib/opportunityApi.ts
+++ b/client/src/lib/opportunityApi.ts
@@ -173,8 +173,9 @@ function resolveOpportunityOwner(
 
 export function mapOpportunityResource(resource: JsonApiResource, included: JsonApiResource[] = []): Opportunity {
   const a = resource.attributes ?? {}
-  const relStage = resource.relationships?.pipeline_stage?.data as { id?: string } | null
-  const relPipe = resource.relationships?.pipeline?.data as { id?: string } | null
+  const relStage   = resource.relationships?.pipeline_stage?.data as { id?: string } | null
+  const relPipe    = resource.relationships?.pipeline?.data    as { id?: string } | null
+  const relContact = resource.relationships?.contact?.data     as { id?: string } | null
 
   const stageId = String(a.pipeline_stage_id ?? relStage?.id ?? '')
   const pipelineId = String(a.pipeline_id ?? relPipe?.id ?? '')
@@ -217,6 +218,7 @@ export function mapOpportunityResource(resource: JsonApiResource, included: Json
 
   return {
     id: String(resource.id ?? ''),
+    contact_id: relContact?.id ? String(relContact.id) : undefined,
     contact_name: String(a.contact_name ?? a.title ?? 'Sin nombre'),
     contact_email: a.contact_email != null ? String(a.contact_email) : undefined,
     contact_phone: a.contact_phone != null ? String(a.contact_phone) : undefined,

--- a/client/src/routes/_app/contacts.tsx
+++ b/client/src/routes/_app/contacts.tsx
@@ -43,6 +43,7 @@ import { toast } from 'sonner'
 import { ContactSlideOver } from '@/components/contacts/ContactSlideOver'
 import { ContactDialog } from '@/components/contacts/ContactDialog'
 import { ContactImportDialog } from '@/components/contacts/ContactImportDialog'
+import { ContactEditDialog } from '@/components/contacts/ContactEditDialog'
 import { QuickAddOpportunity } from '@/components/opportunities/QuickAddOpportunity'
 import { AppPageShell } from '@/components/layout/AppPageShell'
 import { PageHeader } from '@/components/layout/PageHeader'
@@ -50,14 +51,6 @@ import { useUserRole } from '@/stores/auth'
 import api, { formatRailsError } from '@/lib/api'
 import { jsonApiPrimaryList, jsonApiPrimaryOne } from '@/lib/opportunityApi'
 import { queryKeys } from '@/lib/queryClient'
-import {
-  Dialog,
-  DialogContent,
-  DialogFooter,
-  DialogHeader,
-  DialogTitle,
-} from '@/components/ui/dialog'
-import { Label } from '@/components/ui/label'
 
 const contactsSearchSchema = z.object({
   selected: z.string().optional(),
@@ -165,14 +158,6 @@ function ContactsPage() {
   const [isQuickAddOpen, setIsQuickAddOpen] = useState(false)
   const [editingContact, setEditingContact] = useState<ContactRow | null>(null)
   const [isEditDialogOpen, setIsEditDialogOpen] = useState(false)
-  const [editFormData, setEditFormData] = useState({
-    firstName: '',
-    lastName: '',
-    email: '',
-    phone: '',
-    company: '',
-    position: '',
-  })
   const [currentPage, setCurrentPage] = useState(1)
   const [companyPage, setCompanyPage] = useState(1)
   const pageSize = 10
@@ -311,41 +296,8 @@ function ContactsPage() {
 
   const openEditDialog = (contact: ContactRow) => {
     setEditingContact(contact)
-    setEditFormData({
-      firstName: contact.firstName,
-      lastName: contact.lastName,
-      email: contact.email === '-' ? '' : contact.email,
-      phone: contact.phone === '-' ? '' : contact.phone,
-      company: getCompanyLabel(contact.company) === '-' ? '' : getCompanyLabel(contact.company),
-      position: contact.position === '-' ? '' : contact.position,
-    })
     setIsEditDialogOpen(true)
   }
-
-  const updateContactMutation = useMutation({
-    mutationFn: async () => {
-      if (!editingContact) throw new Error('No hay contacto seleccionado')
-      return api.patch(`/contacts/${editingContact.id}`, {
-        contact: {
-          first_name: editFormData.firstName || undefined,
-          last_name: editFormData.lastName || undefined,
-          email: editFormData.email || undefined,
-          phone_e164: editFormData.phone || undefined,
-          company: editFormData.company || undefined,
-          position: editFormData.position || undefined,
-        },
-      })
-    },
-    onSuccess: async () => {
-      await queryClient.invalidateQueries({ queryKey: queryKeys.contacts.all })
-      toast.success('Contacto actualizado')
-      setIsEditDialogOpen(false)
-      setEditingContact(null)
-    },
-    onError: (err: unknown) => {
-      toast.error(formatRailsError(err, 'No se pudo actualizar el contacto'))
-    },
-  })
 
   const deleteContactMutation = useMutation({
     mutationFn: async (contact: ContactRow) => api.delete(`/contacts/${contact.id}`),
@@ -370,9 +322,6 @@ function ContactsPage() {
     deleteContactMutation.mutate(contact)
   }
 
-  const handleEditInputChange = (field: keyof typeof editFormData, value: string) => {
-    setEditFormData((prev) => ({ ...prev, [field]: value }))
-  }
 
   const exportContactsMutation = useMutation({
     mutationFn: async () => {
@@ -808,81 +757,22 @@ function ContactsPage() {
 
       <ContactImportDialog open={importDialogOpen} onOpenChange={setImportDialogOpen} />
 
-      <Dialog open={isEditDialogOpen} onOpenChange={setIsEditDialogOpen}>
-        <DialogContent>
-          <DialogHeader>
-            <DialogTitle>Editar contacto</DialogTitle>
-          </DialogHeader>
-          <form
-            className="space-y-4"
-            onSubmit={(e) => {
-              e.preventDefault()
-              updateContactMutation.mutate()
-            }}
-          >
-            <div className="grid grid-cols-2 gap-4">
-              <div className="space-y-2">
-                <Label htmlFor="edit-first-name">Nombre</Label>
-                <Input
-                  id="edit-first-name"
-                  value={editFormData.firstName}
-                  onChange={(e) => handleEditInputChange('firstName', e.target.value)}
-                />
-              </div>
-              <div className="space-y-2">
-                <Label htmlFor="edit-last-name">Apellido</Label>
-                <Input
-                  id="edit-last-name"
-                  value={editFormData.lastName}
-                  onChange={(e) => handleEditInputChange('lastName', e.target.value)}
-                />
-              </div>
-            </div>
-            <div className="space-y-2">
-              <Label htmlFor="edit-email">Email</Label>
-              <Input
-                id="edit-email"
-                type="email"
-                value={editFormData.email}
-                onChange={(e) => handleEditInputChange('email', e.target.value)}
-              />
-            </div>
-            <div className="space-y-2">
-              <Label htmlFor="edit-phone">Telefono</Label>
-              <Input
-                id="edit-phone"
-                value={editFormData.phone}
-                onChange={(e) => handleEditInputChange('phone', e.target.value)}
-                placeholder="+57..."
-              />
-            </div>
-            <div className="space-y-2">
-              <Label htmlFor="edit-company">Empresa</Label>
-              <Input
-                id="edit-company"
-                value={editFormData.company}
-                onChange={(e) => handleEditInputChange('company', e.target.value)}
-              />
-            </div>
-            <div className="space-y-2">
-              <Label htmlFor="edit-position">Cargo</Label>
-              <Input
-                id="edit-position"
-                value={editFormData.position}
-                onChange={(e) => handleEditInputChange('position', e.target.value)}
-              />
-            </div>
-            <DialogFooter>
-              <Button type="button" variant="outline" onClick={() => setIsEditDialogOpen(false)}>
-                Cancelar
-              </Button>
-              <Button type="submit" disabled={updateContactMutation.isPending}>
-                Guardar cambios
-              </Button>
-            </DialogFooter>
-          </form>
-        </DialogContent>
-      </Dialog>
+      <ContactEditDialog
+        contactId={editingContact?.id ?? null}
+        initialData={editingContact ? {
+          firstName: editingContact.firstName,
+          lastName:  editingContact.lastName,
+          email:     editingContact.email === '-' ? '' : editingContact.email,
+          phone:     editingContact.phone === '-' ? '' : editingContact.phone,
+          company:   getCompanyLabel(editingContact.company) === '-' ? '' : getCompanyLabel(editingContact.company),
+          position:  editingContact.position === '-' ? '' : editingContact.position,
+        } : undefined}
+        open={isEditDialogOpen}
+        onOpenChange={(open) => {
+          setIsEditDialogOpen(open)
+          if (!open) setEditingContact(null)
+        }}
+      />
     </AppPageShell>
   )
 }

--- a/client/src/routes/_app/settings/integrations.tsx
+++ b/client/src/routes/_app/settings/integrations.tsx
@@ -165,6 +165,35 @@ const PROVIDER_CATALOG: ProviderCatalogEntry[] = [
       },
     ],
   },
+  {
+    provider: 'openwa',
+    category: 'messaging',
+    title: 'OpenWA (auto-hospedado)',
+    description:
+      'Pasarela WhatsApp auto-hospedada basada en whatsapp-web.js. No requiere cuenta Business de Meta. ' +
+      'Levanta el servicio OpenWA, escanea el QR con tu teléfono y pega aquí la URL, API key y session ID. ' +
+      'Aviso: usar whatsapp-web.js viola los Términos de Servicio de WhatsApp; el número puede ser baneado.',
+    icon: MessageCircle,
+    accountIdentifierLabel: 'Session ID de OpenWA',
+    accountIdentifierPlaceholder: 'default (o el nombre de tu sesión)',
+    accountIdentifierHint:
+      'El mismo session_id que usaste al crear la sesión en OpenWA (/api/sessions). ' +
+      'Se usa para enlazar los webhooks entrantes al tenant correcto.',
+    credentialFields: [
+      {
+        key: 'url',
+        label: 'URL del servidor OpenWA',
+        type: 'text',
+        placeholder: 'http://localhost:3000',
+      },
+      {
+        key: 'api_key',
+        label: 'API Key de OpenWA',
+        type: 'password',
+        placeholder: 'Clave generada en el panel de OpenWA',
+      },
+    ],
+  },
 ]
 
 const CATEGORIES: { id: CategoryId; name: string; icon: LucideIcon }[] = [
@@ -403,6 +432,9 @@ function IntegrationsSettingsPage() {
             <WebhookUrlRow label="Twilio WhatsApp (POST)" url={webhookUrls.whatsapp_twilio_post} />
             <WebhookUrlRow label="WhatsApp Cloud — verificación (GET)" url={webhookUrls.whatsapp_cloud_verify_get} />
             <WebhookUrlRow label="WhatsApp Cloud — mensajes (POST)" url={webhookUrls.whatsapp_cloud_post} />
+            {webhookUrls.whatsapp_openwa_post ? (
+              <WebhookUrlRow label="OpenWA — eventos (POST)" url={webhookUrls.whatsapp_openwa_post} />
+            ) : null}
           </dl>
         </div>
       ) : null}

--- a/client/src/types/index.ts
+++ b/client/src/types/index.ts
@@ -44,6 +44,7 @@ export type OpportunityStatus = 'new_lead' | 'contacted' | 'qualified' | 'propos
 
 export interface Opportunity {
   id: string
+  contact_id?: string
   contact_name: string
   contact_email?: string
   contact_phone?: string


### PR DESCRIPTION
## Resumen

- **OpenWA (whatsapp-web.js)**: Nuevo proveedor WhatsApp auto-hospedado. Incluye adaptador Rails, webhook controller con verificación HMAC-SHA256, selección automática de proveedor por credenciales, y test de conexión real en `ConnectionTester`.
- **Fix provider-agnostic errors**: Banners y toasts de error en el hilo de WhatsApp ya no mencionan Twilio específicamente — funcionan con cualquier proveedor.
- **Edición de contactos reutilizable**: Nuevo componente `ContactEditDialog` usado tanto en la página de Contactos como en el panel de Oportunidades. Guardar los cambios invalida las queries de contactos y oportunidades simultáneamente para mantener consistencia.

## Cambios principales

### Backend
- `api/app/controllers/api/v1/webhooks/open_wa_controller.rb` — webhook entrante OpenWA
- `api/app/services/whats_app/adapters/open_wa.rb` — adaptador de envío vía OpenWA HTTP API
- `api/app/services/ads/connection_tester.rb` — test real de conexión para integración OpenWA
- `api/app/models/tenant.rb` — `preferred_openwa_integration`, `whatsapp_outbound_provider` con soporte OpenWA; fix en `ad_integration_has_credentials?` para verificar `status == "active"`
- `api/app/models/ad_integration.rb`, `whatsapp_message.rb` — campos y scopes para OpenWA
- `api/app/services/whats_app/message_sender.rb` — despacho al adaptador OpenWA
- `api/config/routes.rb` — ruta webhook `/webhooks/open_wa`

### Frontend
- `client/src/components/contacts/ContactEditDialog.tsx` — nuevo componente reutilizable
- `client/src/routes/_app/contacts.tsx` — usa `ContactEditDialog` en lugar de dialog inline
- `client/src/components/opportunities/OpportunitySlideOver.tsx` — botón de edición de contacto con `ContactEditDialog`
- `client/src/components/opportunities/WhatsAppThread.tsx` — errores independientes del proveedor
- `client/src/lib/opportunityApi.ts` — incluye `contact_id` desde relaciones JSON:API
- `client/src/lib/adIntegrationsApi.ts`, `client/src/routes/_app/settings/integrations.tsx` — UI para configurar integración OpenWA

## Test plan

- [ ] Configurar integración OpenWA en Ajustes → Integraciones y verificar test de conexión
- [ ] Enviar mensaje WhatsApp desde el panel de oportunidad (pestaña WhatsApp)
- [ ] Recibir mensaje entrante vía webhook `/webhooks/open_wa`
- [ ] Editar contacto desde página Contactos y verificar que se refleja en Oportunidades
- [ ] Editar contacto desde el panel lateral de Oportunidades (ícono lápiz en el header)
- [ ] Pausar integración OpenWA y confirmar que no se selecciona como proveedor activo

🤖 Generated with [Claude Code](https://claude.com/claude-code)